### PR TITLE
Definir carpeta proyectos por defecto para guardado y carga

### DIFF
--- a/ScratchMVP.java
+++ b/ScratchMVP.java
@@ -25,6 +25,8 @@ import java.util.List;
  */
 public class ScratchMVP {
 
+    static final File PROJECTS_DIR = new File("proyectos");
+
     // ====== MODELO BÁSICO ======
     enum ShapeType { RECT, CIRCLE, TRIANGLE, PENTAGON, HEXAGON, STAR, POLYGON }
 
@@ -724,6 +726,9 @@ public class ScratchMVP {
 
     // ====== UI GENERAL ======
     public static void main(String[] args) {
+        if (!PROJECTS_DIR.exists()) {
+            PROJECTS_DIR.mkdirs();
+        }
         SwingUtilities.invokeLater(() -> new MainFrame().setVisible(true));
     }
 
@@ -863,13 +868,13 @@ public class ScratchMVP {
             });
 
             btnSaveProj.addActionListener(e -> {
-                JFileChooser fc = new JFileChooser();
+                JFileChooser fc = new JFileChooser(PROJECTS_DIR);
                 if (fc.showSaveDialog(this) == JFileChooser.APPROVE_OPTION) {
                     saveProject(project, fc.getSelectedFile());
                 }
             });
             btnLoadProj.addActionListener(e -> {
-                JFileChooser fc = new JFileChooser();
+                JFileChooser fc = new JFileChooser(PROJECTS_DIR);
                 if (fc.showOpenDialog(this) == JFileChooser.APPROVE_OPTION) {
                     loadProject(project, fc.getSelectedFile());
                     refreshAll();


### PR DESCRIPTION
## Summary
- Crea la carpeta `proyectos` al iniciar la aplicación si no existe.
- Usa `proyectos` como directorio inicial para los diálogos de guardar y cargar proyectos.

## Testing
- `javac ScratchMVP.java`


------
https://chatgpt.com/codex/tasks/task_e_68b63622a3ec8320ad7b2330a6317247