### PR TITLE
Optimiza programación de acciones para evitar saturar el hilo de eventos

### DIFF
--- a/ScratchMVP.java
+++ b/ScratchMVP.java
@@ -390,6 +390,17 @@ public class ScratchMVP {
         Map<String, Map<EventBlock, Double>> varLast = new HashMap<>();
         Map<EventBlock, Double> globalVarLast = new HashMap<>();
         final List<Runnable> pendingOps = new ArrayList<>();
+        static class ScheduledChain {
+            final Entity entity;
+            final Block block;
+            final long runAtMs;
+            ScheduledChain(Entity entity, Block block, long runAtMs) {
+                this.entity = entity;
+                this.block = block;
+                this.runAtMs = runAtMs;
+            }
+        }
+        final List<ScheduledChain> scheduledChains = new ArrayList<>();
 
         GameRuntime(Project p, StagePanel s, Set<Integer> keysDown) {
             this.project = p;
@@ -439,6 +450,16 @@ public class ScratchMVP {
             lastUpdateNs = nowNs;
 
             long nowMs = System.currentTimeMillis();
+
+            for (Iterator<ScheduledChain> it = scheduledChains.iterator(); it.hasNext(); ) {
+                ScheduledChain sc = it.next();
+                if (nowMs >= sc.runAtMs) {
+                    if (stage.entities.contains(sc.entity)) {
+                        executeChain(sc.entity, sc.block);
+                    }
+                    it.remove();
+                }
+            }
 
             // Actualizar movimiento gradual hacia entidades objetivo
             for (Entity en : new ArrayList<>(stage.entities)) {
@@ -701,9 +722,10 @@ public class ScratchMVP {
                 }
                 case WAIT -> {
                     double secs = Double.parseDouble(String.valueOf(ab.args.getOrDefault("secs", 1.0)));
-                    javax.swing.Timer tm = new javax.swing.Timer((int) (secs * 1000), ev -> executeChain(e, ab.next));
-                    tm.setRepeats(false);
-                    tm.start();
+                    if (ab.next != null) {
+                        long runAt = System.currentTimeMillis() + (long) (secs * 1000);
+                        scheduledChains.add(new ScheduledChain(e, ab.next, runAt));
+                    }
                     return false;
                 }
                 case ROTATE_BY -> {


### PR DESCRIPTION
## Summary
- Añade programador interno de cadenas para reanudar acciones después de esperas sin crear múltiples `Timer`s
- Ejecuta acciones programadas en cada actualización garantizando que cada entidad complete su ciclo

## Testing
- `javac ScratchMVP.java`


------
https://chatgpt.com/codex/tasks/task_e_68bc4ffc85488320b86e62a90912c46b