### PR TITLE
Arregla independencia de alto/radio por entidad

### DIFF
--- a/ScratchMVP.java
+++ b/ScratchMVP.java
@@ -1197,6 +1197,7 @@ public class ScratchMVP {
             });
 
             ChangeListener cl = e -> {
+                if (updating) return;
                 Entity sel = listPanel.getSelected();
                 if (sel != null) {
                     double newW = ((Number) wSpin.getValue()).doubleValue();
@@ -1302,9 +1303,9 @@ public class ScratchMVP {
                 };
                 updating = true;
                 shapeBox.setSelectedIndex(idx);
-                updating = false;
                 wSpin.setValue((int)sel.a.width);
                 hSpin.setValue((int)sel.a.height);
+                updating = false;
                 varModel.clear();
                 for (String v : sel.vars.keySet()) varModel.addElement(v);
             } else {


### PR DESCRIPTION
## Resumen
- Evita que los cambios de alto o radio afecten a todas las entidades
- Mantiene los valores del inspector sincronizados sin disparar eventos

## Testing
- `javac ScratchMVP.java`


------
https://chatgpt.com/codex/tasks/task_e_68bcdca7160c83208ae90d2ceba76739