### PR TITLE
Soporte de fondos de imagen y carga automática del último proyecto

### DIFF
--- a/ScratchMVP.java
+++ b/ScratchMVP.java
@@ -3874,7 +3874,9 @@ public class ScratchMVP {
 
             btnSetBg.addActionListener(e -> {
                 JFileChooser fc = new JFileChooser(BACKGROUNDS_DIR);
-                fc.setFileFilter(new FileNameExtensionFilter("PNG", "png"));
+                fc.setFileFilter(new FileNameExtensionFilter(
+                        "Imágenes (PNG, JPG, JPEG, GIF, BMP)",
+                        "png", "jpg", "jpeg", "gif", "bmp"));
                 if (fc.showOpenDialog(StagePanel.this) == JFileChooser.APPROVE_OPTION) {
                     File f = fc.getSelectedFile();
                     Scenario sc = project.scenarios.get(currentScenario);


### PR DESCRIPTION
## Summary
- Permitir seleccionar imágenes PNG de la carpeta `fondos` como fondo del escenario.
- Redimensionar el fondo al cambiar el tamaño del escenario y crear la carpeta `fondos` al iniciar.
- Cargar automáticamente el proyecto más reciente de la carpeta `proyectos` al iniciar la aplicación.

## Testing
- `javac ScratchMVP.java`


------
https://chatgpt.com/codex/tasks/task_e_68c419cd063c83209bfddcef0d6acf90